### PR TITLE
Add CSRF validation to ticket admin actions

### DIFF
--- a/admin_tickets.php
+++ b/admin_tickets.php
@@ -12,36 +12,41 @@ if (!es_admin($pdo)) {
 // Ejecutar escalamiento automático
 escalamiento_automatico($pdo);
 
-// Si se recibe un ID para borrar
-if (isset($_GET["eliminar"])) {
-    $id = intval($_GET["eliminar"]);
-
-    // Borrar respuestas primero
-    $pdo->prepare("DELETE FROM respuestas WHERE id_ticket = ?")->execute([$id]);
-    // Luego el ticket
-    $pdo->prepare("DELETE FROM tickets WHERE id = ?")->execute([$id]);
-
-    header("Location: admin_tickets.php");
-    exit();
-}
-
-// Manejar asignación de técnico
-if (isset($_POST['asignar_tecnico'])) {
-    $ticket_id = intval($_POST['ticket_id']);
-    $stmt = $pdo->prepare("UPDATE tickets SET tecnico_asignado = 1, estado = 'En Progreso' WHERE id = ?");
-    $stmt->execute([$ticket_id]);
-    
-    // Crear notificación
-    $stmt_user = $pdo->prepare("SELECT id_usuario FROM tickets WHERE id = ?");
-    $stmt_user->execute([$ticket_id]);
-    $user_id = $stmt_user->fetchColumn();
-    
-    if ($user_id) {
-        crear_notificacion($pdo, $user_id, "Ticket asignado", "Tu ticket ha sido asignado a un técnico especializado", "info");
+if ($_SERVER["REQUEST_METHOD"] === "POST") {
+    if (!csrf_check($_POST["csrf"] ?? '')) {
+        echo "Token CSRF inválido.";
+        exit();
     }
-    
-    header("Location: admin_tickets.php");
-    exit();
+
+    if (isset($_POST["eliminar"])) {
+        $id = intval($_POST["eliminar"]);
+
+        // Borrar respuestas primero
+        $pdo->prepare("DELETE FROM respuestas WHERE id_ticket = ?")->execute([$id]);
+        // Luego el ticket
+        $pdo->prepare("DELETE FROM tickets WHERE id = ?")->execute([$id]);
+
+        header("Location: admin_tickets.php");
+        exit();
+    }
+
+    if (isset($_POST['asignar_tecnico'])) {
+        $ticket_id = intval($_POST['ticket_id']);
+        $stmt = $pdo->prepare("UPDATE tickets SET tecnico_asignado = 1, estado = 'En Progreso' WHERE id = ?");
+        $stmt->execute([$ticket_id]);
+
+        // Crear notificación
+        $stmt_user = $pdo->prepare("SELECT id_usuario FROM tickets WHERE id = ?");
+        $stmt_user->execute([$ticket_id]);
+        $user_id = $stmt_user->fetchColumn();
+
+        if ($user_id) {
+            crear_notificacion($pdo, $user_id, "Ticket asignado", "Tu ticket ha sido asignado a un técnico especializado", "info");
+        }
+
+        header("Location: admin_tickets.php");
+        exit();
+    }
 }
 
 // Filtros para admin
@@ -242,6 +247,7 @@ $stats = obtener_estadisticas_dashboard($pdo, null, true);
                                     <span style="color: #38a169; font-weight: 600;">✓ Asignado</span>
                                 <?php else: ?>
                                     <form method="POST" style="display: inline; background: none; padding: 0; box-shadow: none; border: none;">
+                                        <input type="hidden" name="csrf" value="<?php echo csrf_token(); ?>">
                                         <input type="hidden" name="ticket_id" value="<?php echo $t['id']; ?>">
                                         <button type="submit" name="asignar_tecnico" style="padding: 4px 8px; font-size: 0.8em; margin: 0;">
                                             Asignar
@@ -255,7 +261,11 @@ $stats = obtener_estadisticas_dashboard($pdo, null, true);
                             </td>
                             <td>
                                 <a href="admin_ver_ticket.php?id=<?php echo $t["id"]; ?>">Ver</a> |
-                                <a href="admin_tickets.php?eliminar=<?php echo $t["id"]; ?>" class="eliminar" onclick="return confirm('¿Seguro que deseas eliminar este ticket y sus respuestas?')">Eliminar</a>
+                                <form method="POST" style="display:inline;" onsubmit="return confirm('¿Seguro que deseas eliminar este ticket y sus respuestas?')">
+                                    <input type="hidden" name="csrf" value="<?php echo csrf_token(); ?>">
+                                    <input type="hidden" name="eliminar" value="<?php echo $t['id']; ?>">
+                                    <button type="submit" class="eliminar" style="background:none;border:none;padding:0;">Eliminar</button>
+                                </form>
                             </td>
                         </tr>
                     <?php endforeach; ?>

--- a/admin_ver_ticket.php
+++ b/admin_ver_ticket.php
@@ -20,6 +20,11 @@ if (!$ticket) {
 }
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!csrf_check($_POST["csrf"] ?? '')) {
+        echo "Token CSRF inválido.";
+        exit();
+    }
+
     if (isset($_POST["respuesta"])) {
         $respuesta = limpiar($_POST["respuesta"]);
         $autor = "Soporte VW";
@@ -181,16 +186,17 @@ $plantillas = obtener_plantillas_respuestas($pdo);
             <!-- Acciones administrativas -->
             <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 20px; margin-bottom: 20px;">
                 <div style="background: rgba(255, 255, 255, 0.95); padding: 16px; border-radius: 12px; border-left: 4px solid #4299e1;">
-                    <h4>🔄 Cambiar Estado</h4>
-                    <form method="POST" style="background: none; padding: 0; box-shadow: none; border: none;">
-                        <select name="nuevo_estado" style="margin-bottom: 8px;">
-                            <option value="Abierto" <?php echo $ticket["estado"] === 'Abierto' ? 'selected' : ''; ?>>Abierto</option>
-                            <option value="En Progreso" <?php echo $ticket["estado"] === 'En Progreso' ? 'selected' : ''; ?>>En Progreso</option>
-                            <option value="Cerrado" <?php echo $ticket["estado"] === 'Cerrado' ? 'selected' : ''; ?>>Cerrado</option>
-                        </select>
-                        <button type="submit" name="cambiar_estado" style="width: 100%; margin: 0;">Actualizar Estado</button>
-                    </form>
-                </div>
+            <h4>🔄 Cambiar Estado</h4>
+            <form method="POST" style="background: none; padding: 0; box-shadow: none; border: none;">
+                <input type="hidden" name="csrf" value="<?php echo csrf_token(); ?>">
+                <select name="nuevo_estado" style="margin-bottom: 8px;">
+                    <option value="Abierto" <?php echo $ticket["estado"] === 'Abierto' ? 'selected' : ''; ?>>Abierto</option>
+                    <option value="En Progreso" <?php echo $ticket["estado"] === 'En Progreso' ? 'selected' : ''; ?>>En Progreso</option>
+                    <option value="Cerrado" <?php echo $ticket["estado"] === 'Cerrado' ? 'selected' : ''; ?>>Cerrado</option>
+                </select>
+                <button type="submit" name="cambiar_estado" style="width: 100%; margin: 0;">Actualizar Estado</button>
+            </form>
+        </div>
                 
                 <div style="background: rgba(255, 255, 255, 0.95); padding: 16px; border-radius: 12px; border-left: 4px solid #38a169;">
                     <h4>⏱️ Información de Tiempo</h4>
@@ -201,11 +207,12 @@ $plantillas = obtener_plantillas_respuestas($pdo);
                 </div>
             </div>
             
-            <h3>💬 Responder como soporte</h3>
-            <form method="POST">
-                <?php if (!empty($plantillas)): ?>
-                <label>Plantilla de respuesta (opcional):</label>
-                <select name="plantilla_id" onchange="cargarPlantilla(this.value)" style="margin-bottom: 16px;">
+        <h3>💬 Responder como soporte</h3>
+        <form method="POST">
+            <input type="hidden" name="csrf" value="<?php echo csrf_token(); ?>">
+            <?php if (!empty($plantillas)): ?>
+            <label>Plantilla de respuesta (opcional):</label>
+            <select name="plantilla_id" onchange="cargarPlantilla(this.value)" style="margin-bottom: 16px;">
                     <option value="">-- Seleccionar plantilla --</option>
                     <?php foreach ($plantillas as $plantilla): ?>
                         <option value="<?php echo $plantilla['id']; ?>" data-contenido="<?php echo htmlspecialchars($plantilla['contenido']); ?>">

--- a/ver_ticket_detalle.php
+++ b/ver_ticket_detalle.php
@@ -29,6 +29,11 @@ if (!$ticket) {
 }
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    if (!csrf_check($_POST["csrf"] ?? '')) {
+        echo "Token CSRF inválido.";
+        exit();
+    }
+
     $respuesta = limpiar($_POST["respuesta"]);
     $autor = $_SESSION["usuario_nombre"];
 
@@ -117,6 +122,7 @@ $respuestas = $stmt->fetchAll();
             <hr>
             <h3>Agregar respuesta</h3>
             <form method="POST">
+                <input type="hidden" name="csrf" value="<?php echo csrf_token(); ?>">
                 <textarea name="respuesta" rows="4" required></textarea><br>
                 <button type="submit">Enviar</button>
             </form>


### PR DESCRIPTION
## Summary
- Protect ticket state changes and support responses with CSRF tokens
- Enforce CSRF validation when users respond to tickets
- Require POST + CSRF tokens for ticket deletion and technician assignment

## Testing
- `php -l admin_ver_ticket.php`
- `php -l ver_ticket_detalle.php`
- `php -l admin_tickets.php`


------
https://chatgpt.com/codex/tasks/task_e_68b07a7964e08322a406f05ae0cc2dcb